### PR TITLE
Hook & patch to automatically update imports

### DIFF
--- a/hook/apply-filechooser-patch
+++ b/hook/apply-filechooser-patch
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+patch_file='plugin/com.cesidiodibenedetto.filechooser/patch/android-platform-filechooser.patch'
+package="$(sed -rn '/^<manifest /s/.*package="([^"]+)".*/\1/p' platforms/android/AndroidManifest.xml)"
+
+gen_patch() {
+	sed "s/PACKAGE/$package/" < "$patch_file"
+}
+
+if ! patch -v > /dev/null
+then
+	echo "Missing 'patch' command." >&2
+	exit 1
+fi
+
+if gen_patch | ( cd platforms/android && patch -p1 --dry-run --batch --forward --silent >/dev/null )
+then
+	gen_patch | ( cd platforms/android && patch -p1 --batch --forward -r - )
+else
+	echo "Skipping patches, they are already applied or broken." >&2
+fi
+

--- a/patch/android-platform-filechooser.patch
+++ b/patch/android-platform-filechooser.patch
@@ -1,0 +1,84 @@
+diff -ruw android.orig/src/com/cesidiodibenedetto/filechooser/FileChooser.java android/src/com/cesidiodibenedetto/filechooser/FileChooser.java
+--- android.orig/src/com/cesidiodibenedetto/filechooser/FileChooser.java	2015-06-22 18:55:47.000000000 +0200
++++ android/src/com/cesidiodibenedetto/filechooser/FileChooser.java	2015-06-22 19:01:52.908404787 +0200
+@@ -22,6 +22,8 @@
+ 
+ import com.ipaulpro.afilechooser.utils.FileUtils;
+ 
++import PACKAGE.R;
++
+ /**
+  * FileChooser is a PhoneGap plugin that acts as polyfill for Android KitKat and web
+  * applications that need support for <input type="file">
+diff -ruw android.orig/src/com/ianhanniballake/localstorage/LocalStorageProvider.java android/src/com/ianhanniballake/localstorage/LocalStorageProvider.java
+--- android.orig/src/com/ianhanniballake/localstorage/LocalStorageProvider.java	2015-06-22 18:55:47.000000000 +0200
++++ android/src/com/ianhanniballake/localstorage/LocalStorageProvider.java	2015-06-22 19:01:52.900404713 +0200
+@@ -21,6 +21,8 @@
+ import java.io.FileOutputStream;
+ import java.io.IOException;
+ 
++import PACKAGE.R;
++
+ public class LocalStorageProvider extends DocumentsProvider {
+ 
+     public static final String AUTHORITY = "com.ianhanniballake.localstorage.documents";
+diff -ruw android.orig/src/com/ipaulpro/afilechooser/FileChooserActivity.java android/src/com/ipaulpro/afilechooser/FileChooserActivity.java
+--- android.orig/src/com/ipaulpro/afilechooser/FileChooserActivity.java	2015-06-22 18:55:47.000000000 +0200
++++ android/src/com/ipaulpro/afilechooser/FileChooserActivity.java	2015-06-22 18:59:58.815348192 +0200
+@@ -36,6 +36,8 @@
+ 
+ import java.io.File;
+ 
++import PACKAGE.R;
++
+ /**
+  * Main Activity that handles the FileListFragments
+  *
+diff -ruw android.orig/src/com/ipaulpro/afilechooser/FileListAdapter.java android/src/com/ipaulpro/afilechooser/FileListAdapter.java
+--- android.orig/src/com/ipaulpro/afilechooser/FileListAdapter.java	2015-06-22 18:55:47.000000000 +0200
++++ android/src/com/ipaulpro/afilechooser/FileListAdapter.java	2015-06-22 18:59:03.178832147 +0200
+@@ -27,6 +27,8 @@
+ import java.util.ArrayList;
+ import java.util.List;
+ 
++import PACKAGE.R;
++
+ /**
+  * List adapter for Files.
+  * 
+diff -ruw android.orig/src/com/ipaulpro/afilechooser/FileListFragment.java android/src/com/ipaulpro/afilechooser/FileListFragment.java
+--- android.orig/src/com/ipaulpro/afilechooser/FileListFragment.java	2015-06-22 18:55:47.000000000 +0200
++++ android/src/com/ipaulpro/afilechooser/FileListFragment.java	2015-06-22 18:59:40.251176067 +0200
+@@ -28,6 +28,8 @@
+ import java.io.File;
+ import java.util.List;
+ 
++import PACKAGE.R;
++
+ /**
+  * Fragment that displays a list of Files in a given path.
+  * 
+diff -ruw android.orig/src/com/ipaulpro/afilechooser/FileLoader.java android/src/com/ipaulpro/afilechooser/FileLoader.java
+--- android.orig/src/com/ipaulpro/afilechooser/FileLoader.java	2015-06-22 18:55:47.000000000 +0200
++++ android/src/com/ipaulpro/afilechooser/FileLoader.java	2015-06-22 19:00:41.147740468 +0200
+@@ -27,6 +27,8 @@
+ import java.util.Arrays;
+ import java.util.List;
+ 
++import PACKAGE.R;
++
+ /**
+  * Loader that returns a list of Files in a given file path.
+  * 
+diff -ruw android.orig/src/com/ipaulpro/afilechooser/utils/FileUtils.java android/src/com/ipaulpro/afilechooser/utils/FileUtils.java
+--- android.orig/src/com/ipaulpro/afilechooser/utils/FileUtils.java	2015-06-22 18:55:47.000000000 +0200
++++ android/src/com/ipaulpro/afilechooser/utils/FileUtils.java	2015-06-22 19:00:49.395816864 +0200
+@@ -38,6 +38,8 @@
+ import java.text.DecimalFormat;
+ import java.util.Comparator;
+ 
++import PACKAGE.R;
++
+ /**
+  * @version 2009-07-03
+  * @author Peli


### PR DESCRIPTION
The hook should be in plugin. This hook is picked up from a project which uses Filechooser, so some integration must be done before this is universally usable and fully automated. 
